### PR TITLE
Add support for symfony >= 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.3.6",
         "behat/behat": ">=2.4.6,<2.5.0",
-        "symfony/process": "2.2.*"
+        "symfony/process": ">=2.2.0"
     },
     "autoload": {
         "psr-0": { "shvetsgroup\\ParallelRunner": "src/" }


### PR DESCRIPTION
Hi, 

I'm using Symfony 2.3 and wanted to try your extension. Here is the patch to allow Symfony >= 2.2.

fixes #12
