### PR TITLE
Add WorkerException to allow serializing even when the trace contains closures (which are not serializable)

### DIFF
--- a/src/shvetsgroup/ParallelRunner/Exception/WorkerException.php
+++ b/src/shvetsgroup/ParallelRunner/Exception/WorkerException.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @copyright 2013 Andreas Streichardt
+ * @license MIT
+ */
+
+namespace shvetsgroup\ParallelRunner\Exception;
+
+
+/**
+ * Serializeable Exception. The normal exception might contain closures in the trace which are NOT serializable
+ *
+ * @package shvetsgroup\ParallelRunner\Exception
+ */
+class WorkerException extends \Exception implements \Serializable
+{
+    /**
+     * @return string
+     */
+    public function serialize()
+    {
+        return serialize(array($this->message, $this->code));
+    }
+
+    /**
+     * @param string $serialized
+     */
+    public function unserialize($serialized)
+    {
+        list($this->message, $this->code) = unserialize($serialized);
+    }
+}

--- a/src/shvetsgroup/ParallelRunner/Service/EventService.php
+++ b/src/shvetsgroup/ParallelRunner/Service/EventService.php
@@ -10,6 +10,7 @@ use Behat\Behat\Event\OutlineExampleEvent;
 use Behat\Behat\Event\ScenarioEvent;
 use Behat\Behat\Event\StepEvent;
 use shvetsgroup\ParallelRunner\Context\NullContext;
+use shvetsgroup\ParallelRunner\Exception\WorkerException;
 use shvetsgroup\ParallelRunner\EventDispatcher\NullEventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcher,
   Symfony\Component\DependencyInjection\ContainerInterface;
@@ -153,7 +154,7 @@ class EventService
                     new NullContext(),
                     $event->getResult(),
                     null,
-                    $event->getException() ? new \Exception($event->getException()->getMessage()) : null,
+                    $event->getException() ? new WorkerException($event->getException()->getMessage()) : null,
                     $event->getSnippet()
                 );
             }


### PR DESCRIPTION
When the workers are producing an exception the stack trace may contain closures and then you would get "serialization of 'closure' is not allowed". To work around the problem i created a simple Exception which handles serialization on its own.
