### PR TITLE
Possibility to inform the context which worker is currently active

### DIFF
--- a/src/shvetsgroup/ParallelRunner/Console/Command/ParallelRunnerCommand.php
+++ b/src/shvetsgroup/ParallelRunner/Console/Command/ParallelRunnerCommand.php
@@ -8,6 +8,7 @@ namespace shvetsgroup\ParallelRunner\Console\Command;
 
 use Behat\Behat\Console\Command\BehatCommand, Behat\Behat\Event\SuiteEvent;
 
+use shvetsgroup\ParallelRunner\Worker;
 use Symfony\Component\DependencyInjection\ContainerInterface, Symfony\Component\Console\Input\InputOption,
   Symfony\Component\Console\Input\InputInterface, Symfony\Component\Console\Output\OutputInterface,
   Symfony\Component\Process\Process;
@@ -186,6 +187,9 @@ class ParallelRunnerCommand extends BehatCommand
      */
     protected function runWorker()
     {
+        $worker = new Worker($this->workerID);
+        $this->getContainer()->get('behat.parallel_runner.context.initializer')->setWorker($worker);
+
         $this->registerWorkerSignal();
 
         // We don't need any formatters, but event recorder for worker process.

--- a/src/shvetsgroup/ParallelRunner/Context/Initializer/WorkerAwareInitializer.php
+++ b/src/shvetsgroup/ParallelRunner/Context/Initializer/WorkerAwareInitializer.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @copyright 2013 Andreas Streichardt
+ * @license MIT
+ */
+
+namespace shvetsgroup\ParallelRunner\Context\Initializer;
+
+use Behat\Behat\Context\ContextInterface;
+use Behat\Behat\Context\Initializer\InitializerInterface;
+use shvetsgroup\ParallelRunner\Context\WorkerAwareInterface;
+use shvetsgroup\ParallelRunner\Worker;
+
+class WorkerAwareInitializer implements InitializerInterface
+{
+    private $worker;
+
+    public function setWorker(Worker $worker)
+    {
+        $this->worker = $worker;
+    }
+
+    public function supports(ContextInterface $context)
+    {
+        return $context instanceof WorkerAwareInterface;
+    }
+
+    /**
+     * Initializes provided context.
+     *
+     * @param ContextInterface $context
+     */
+    public function initialize(ContextInterface $context)
+    {
+        if ($this->worker) {
+            $context->setWorker($this->worker);
+        }
+    }
+}

--- a/src/shvetsgroup/ParallelRunner/Context/WorkerAwareInterface.php
+++ b/src/shvetsgroup/ParallelRunner/Context/WorkerAwareInterface.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @copyright 2013 Andreas Streichardt
+ * @license MIT
+ */
+
+namespace shvetsgroup\ParallelRunner\Context;
+
+use shvetsgroup\ParallelRunner\Worker;
+
+interface WorkerAwareInterface
+{
+    public function setWorker(Worker $worker);
+}

--- a/src/shvetsgroup/ParallelRunner/Extension.php
+++ b/src/shvetsgroup/ParallelRunner/Extension.php
@@ -44,6 +44,14 @@ class Extension implements ExtensionInterface
 
         $container->setParameter('parallel.process_count', $config['process_count']);
         $container->setParameter('parallel.profiles', $config['profiles']);
+
+        $container
+            ->register(
+                'behat.parallel_runner.context.initializer',
+                '\shvetsgroup\ParallelRunner\Context\Initializer\WorkerAwareInitializer'
+            )
+            ->addTag('behat.context.initializer')
+        ;
     }
 
     /**

--- a/src/shvetsgroup/ParallelRunner/Worker.php
+++ b/src/shvetsgroup/ParallelRunner/Worker.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @copyright 2013 Andreas Streichardt
+ * @license MIT
+ */
+
+namespace shvetsgroup\ParallelRunner;
+
+
+class Worker
+{
+    private $id;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+}


### PR DESCRIPTION
We are doing data setup steps in most of our behat tests and we are running our parallel jobs on different databases (so they don't interfere). However our Context (which inserts the data) needs to know which worker is currently active. So i implemented a WorkerAwareInterface for Contexts (that behat thing must have been written by Java enthusiasts :|) so i can target the correct database for the data.

What do you think about this?

Currently i am doing evil stuff like this in our Contexts (however it is sufficient to do the job right now):

if ($this->worker->getId() == 1) {
   $targetDatabase = "database2";
} else {
   $targetDatabase = "database1";
}

For the future i need to be able to specify arbitrary worker data in here:

```
   shvetsgroup\ParallelRunner\Extension:
       profiles:
           - firefox
           - chrome
```

Any idea what a good approach would be?

Maybe:

```
   shvetsgroup\ParallelRunner\Extension:
       profiles:
           firefox:
              database: database1
           chrome:
              database: database2
```

What do you think? is my patch useful at all? Am i the only one doing such stuff?
