### PR TITLE
Do not add a value to VALUE_NONE Input options

### DIFF
--- a/src/shvetsgroup/ParallelRunner/Console/Command/ParallelRunnerCommand.php
+++ b/src/shvetsgroup/ParallelRunner/Console/Command/ParallelRunnerCommand.php
@@ -110,9 +110,14 @@ class ParallelRunnerCommand extends BehatCommand
         foreach ($input->getArguments() as $argument) {
             $command_template[] = $argument;
         }
+        $definition = $this->getDefinition();
         foreach ($input->getOptions() as $option => $value) {
             if ($value && $option != 'parallel' && $option != 'profile') {
-                $command_template[] = "--$option='$value'";
+                if ($definition->getOption($option)->acceptValue()) {
+                    $command_template[] = "--$option='$value'";
+                } else {
+                    $command_template[] = "--$option";
+                }
             }
         }
         if (!$input->getOption('cache')) {


### PR DESCRIPTION
Simple test:

behat -l2 --verbose

The childcommands will fail as they generate a command "--verbose='1'". verbose is one of the options which don't accept any values
