### PR TITLE
Update package requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This extension requires:
 {
     "require": {
         ...
-        "shvetsgroup/parallelrunner": "*"
+        "shvetsgroup/parallelrunner": "dev-master"
     }
 }
 ```


### PR DESCRIPTION
`*` only works as a package requirement if there are tagged versions. Since this package has none, `dev-master` or similar is required.
