### PR TITLE
Add PCNTL extension to composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     ],
     "require": {
         "php": ">=5.3.6",
+        "ext-pcntl": "*",
         "behat/behat": ">=2.4.6,<2.5.0",
         "symfony/process": ">=2.2.0"
     },


### PR DESCRIPTION
the extension is used in the Command, but it is not required in composer.json
